### PR TITLE
Disabled node exporter

### DIFF
--- a/helm-releases/prometheus.yaml
+++ b/helm-releases/prometheus.yaml
@@ -17,6 +17,8 @@ spec:
         name: prometheus
       interval: 10m
   values:
+    prometheus-node-exporter:
+      enabled: false
     prometheus-pushgateway:
       enabled: false
     alertmanager:


### PR DESCRIPTION
- node exporter is a stand alone helm release now