### PR TITLE
fix: Sealed Secrets CRD moved to dependencies

### DIFF
--- a/dependencies/sealed-secrets-crd.yaml
+++ b/dependencies/sealed-secrets-crd.yaml
@@ -1,0 +1,170 @@
+{{ if .sealedSecrets.enabled -}}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: sealedsecrets.bitnami.com
+spec:
+  group: bitnami.com
+  names:
+    kind: SealedSecret
+    listKind: SealedSecretList
+    plural: sealedsecrets
+    singular: sealedsecret
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].message
+      name: Status
+      type: string
+    - jsonPath: .status.conditions[0].status
+      name: Synced
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          SealedSecret is the K8s representation of a "sealed Secret" - a
+          regular k8s Secret that has been sealed (encrypted) using the
+          controller's key.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SealedSecretSpec is the specification of a SealedSecret.
+            properties:
+              data:
+                description: Data is deprecated and will be removed eventually. Use
+                  per-value EncryptedData instead.
+                format: byte
+                type: string
+              encryptedData:
+                additionalProperties:
+                  type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              template:
+                description: |-
+                  Template defines the structure of the Secret that will be
+                  created from this sealed secret.
+                properties:
+                  data:
+                    additionalProperties:
+                      type: string
+                    description: Keys that should be templated using decrypted data.
+                    nullable: true
+                    type: object
+                  immutable:
+                    description: |-
+                      Immutable, if set to true, ensures that data stored in the Secret cannot
+                      be updated (only object metadata can be modified).
+                      If not set to true, the field can be modified at any time.
+                      Defaulted to nil.
+                    type: boolean
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+                    nullable: true
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type:
+                    description: Used to facilitate programmatic handling of secret
+                      data.
+                    type: string
+                type: object
+            required:
+            - encryptedData
+            type: object
+          status:
+            description: SealedSecretStatus is the most recently observed status of
+              the SealedSecret.
+            properties:
+              conditions:
+                description: Represents the latest available observations of a sealed
+                  secret's current state.
+                items:
+                  description: SealedSecretCondition describes the state of a sealed
+                    secret at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status of the condition for a sealed secret.
+                        Valid values for "Synced": "True", "False", or "Unknown".
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition for a sealed secret.
+                        Valid value: "Synced"
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the generation most recently
+                  observed by the sealed-secrets controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/helm-releases/sealed-secrets.yaml
+++ b/helm-releases/sealed-secrets.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   interval: 60m
   releaseName: sealed-secrets-controller
+  crds: Skip
   chart:
     spec:
       chart: sealed-secrets

--- a/helm-releases/sealed-secrets.yaml
+++ b/helm-releases/sealed-secrets.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   interval: 60m
   releaseName: sealed-secrets-controller
-  crds: Skip
+  install:
+    crds: Skip
   chart:
     spec:
       chart: sealed-secrets

--- a/stack-definition.yaml
+++ b/stack-definition.yaml
@@ -1349,8 +1349,7 @@ components:
         }
       ]
 changeLog: |
-  - 🍏 Gimlet Agent to beta.14, if deployed with Gimlet beta.14 enables support for Docker build contexts and better error handling
-  - 🐛 fix: updated sealed-secrets version format 
+  - 🐛 fix: Sealed Secrets CRD moved to dependencies. It often prevented applying the gitops repo on new clusters.
 message: |
 
   Hey 👋 Laszlo here, the founder of Gimlet.io


### PR DESCRIPTION
When an existing infra gitops repo was pointed to an empty cluster, apply often failed with a catch 22. If there were sealed secrets resources in the `manifests` folder, and the `helm-releases` folder was not applied yet, Flux failed to apply the repo. With this change, the CRD will be applied first in the `dependencies` folder, and then it does not matter in what order the `manifests` and the `helm-releases` folder is applied.

As an alternative, why not the whole Sealed Secret HelmRelease was moved? Because that would have been a move between two Flux Kustomizations. That in essence is a delete then a subsequent apply, in which sealed secrets would have been recreated. This is unwanted behavior. (what could have been prevented by setting a `prune: false` then back `prune: true`, but that would have been a cumbersome update experience.)